### PR TITLE
Add first load completion handling and visibility updates

### DIFF
--- a/Core/GameStateService.cs
+++ b/Core/GameStateService.cs
@@ -92,7 +92,7 @@ namespace EliteInfoPanel.Core
             get => _currentSystemCoordinates;
             set => SetProperty(ref _currentSystemCoordinates, value);
         }
-
+      
         public bool FirstLoadCompleted => _firstLoadCompleted;
 
         public double MaxJumpRange
@@ -303,7 +303,7 @@ namespace EliteInfoPanel.Core
         // Event for hyperspace jump notification
         public event Action<bool, string> HyperspaceJumping;
         public event Action LoadoutUpdated;
-
+        public event Action FirstLoadCompletedEvent;
 
         #endregion
 
@@ -755,8 +755,14 @@ namespace EliteInfoPanel.Core
             latestJournalPath = Directory.GetFiles(gamePath, "Journal.*.log")
                 .OrderByDescending(File.GetLastWriteTime)
                 .FirstOrDefault();
+            _firstLoadCompleted = true;
+            Log.Information("✅ First journal scan completed");
+
+            FirstLoadCompletedEvent?.Invoke(); // 🔔 raise the event here
+
 
             LoadRouteProgress();
+
             Task.Run(async () => await ProcessJournalAsync()).Wait();
             OnPropertyChanged(nameof(CurrentLoadout));
             OnPropertyChanged(nameof(CurrentCargo));
@@ -964,6 +970,8 @@ namespace EliteInfoPanel.Core
                         case "DockingGranted":
                             Log.Information("Docking granted by station — setting IsDocking = true");
                             SetDockingStatus();
+                           
+                            SetProperty(ref _isDocking, true, nameof(IsDocking));
                             break;
 
                         case "CarrierJumpRequest":

--- a/ViewModels/CardViewModel.cs
+++ b/ViewModels/CardViewModel.cs
@@ -27,14 +27,24 @@ namespace EliteInfoPanel.ViewModels
             get => _isVisible;
             set
             {
-                if (SetProperty(ref _isVisible, value))
+                if (_isVisible != value)
                 {
-                    // Critical - Notify the main view model that a card's visibility has changed
-                    Log.Information("{CardType}: IsVisible changed to {IsVisible}", this.GetType().Name, value);
-                    NotifyCardVisibilityChanged();
+                    _isVisible = value;
+
+                    if (System.Windows.Application.Current.Dispatcher.CheckAccess())
+                    {
+                        NotifyCardVisibilityChanged();
+                    }
+                    else
+                    {
+                        System.Windows.Application.Current.Dispatcher.Invoke(NotifyCardVisibilityChanged);
+                    }
+
+                    OnPropertyChanged();
                 }
             }
         }
+
 
         // Add this method to the CardViewModel class:
 

--- a/ViewModels/RouteViewModel.cs
+++ b/ViewModels/RouteViewModel.cs
@@ -66,6 +66,8 @@ namespace EliteInfoPanel.ViewModels
             StarClass = starClass;
             SystemAddress = systemAddress;
             ItemType = itemType;
+           
+
         }
         #endregion
     }
@@ -162,7 +164,11 @@ namespace EliteInfoPanel.ViewModels
 
             // Subscribe to relevant property changes from GameStateService
             _gameState.PropertyChanged += GameState_PropertyChanged;
-
+            _gameState.FirstLoadCompletedEvent += () =>
+            {
+                Log.Debug("RouteViewModel: FirstLoadCompleted triggered — forcing route update");
+                RequestRouteUpdate();
+            };
             // Do initial update
             RequestRouteUpdate();
         }


### PR DESCRIPTION
- Exposed `_firstLoadCompleted` with a new property in `GameStateService.cs`.
- Introduced `FirstLoadCompletedEvent` to notify when the first load is done.
- Set `_firstLoadCompleted` to `true` and invoked the event after the first journal scan.
- Enhanced `IsVisible` property in `CardViewModel.cs` to check for changes and notify on the UI thread.
- Added `NotifyCardVisibilityChanged` method for handling visibility notifications.
- Subscribed to `FirstLoadCompletedEvent` in `RouteViewModel.cs` for route updates. Fixes #43